### PR TITLE
Fixed issues with latest Foundation version

### DIFF
--- a/app/templates/_bower.json
+++ b/app/templates/_bower.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "dependencies": {<% if (bootstrap) { %>
     "bootstrap": ">=3.1.1",<% } if (foundation) { %>
-    "foundation": ">=5.2.3",<% } if (modernizr) { %>
+    "foundation": "~5.3.3",<% } if (modernizr) { %>
     "modernizr": "~2.8.2"<% } %>
   }
 }

--- a/app/templates/scss/_foundation.scss
+++ b/app/templates/scss/_foundation.scss
@@ -9,6 +9,7 @@
 /* Foundation Components (comment out as necessary)
    ======================================================================== */
 @import
+  "foundation/components/grid",
   "foundation/components/accordion",
   "foundation/components/alert-boxes",
   "foundation/components/block-grid",
@@ -20,7 +21,7 @@
   "foundation/components/dropdown-buttons",
   "foundation/components/flex-video",
   "foundation/components/forms",
-  "foundation/components/grid",
+  "foundation/components/icon-bar",
   "foundation/components/inline-lists",
   "foundation/components/joyride",
   "foundation/components/keystrokes",
@@ -31,11 +32,12 @@
   "foundation/components/panels",
   "foundation/components/pricing-tables",
   "foundation/components/progress-bars",
+  "foundation/components/range-slider",
   "foundation/components/reveal",
   "foundation/components/side-nav",
   "foundation/components/split-buttons",
   "foundation/components/sub-nav",
-  "foundation/components/switch",
+  "foundation/components/switches",
   "foundation/components/tables",
   "foundation/components/tabs",
   "foundation/components/thumbs",

--- a/app/templates/scss/app.scss
+++ b/app/templates/scss/app.scss
@@ -6,8 +6,8 @@
 
 /* Vendor Styles and Setting (foundation > settings)
    ======================================================================== */
-@import "foundation";
 @import "settings";
+@import "foundation";
 
 
 /* Mixins (User defined mixins)


### PR DESCRIPTION
The latest foundation version renamed the switch component to switches and added a few new components. I've updated the bower.json with Foundation 5.3.3 and also included a more stable semver version selector so this won't break so easily in the future. It's also important that you include the local Foundation setting overrides before the actual component imports.

Cheers
Gion
